### PR TITLE
Fixing errors of undefined _this_ keyword stemming from unbound metho…

### DIFF
--- a/examples/react/src/TodoItem.js
+++ b/examples/react/src/TodoItem.js
@@ -9,6 +9,11 @@ class TodoItem extends Component {
 	constructor(props) {
 		super(props);
 		this.state = { editText: this.props.todo.title };
+
+		this.handleSubmit = this.handleSubmit.bind(this);
+		this.handleEdit = this.handleEdit.bind(this);
+		this.handleKeyDown = this.handleKeyDown.bind(this);
+		this.handleChange = this.handleChange.bind(this);
 	}
 	handleSubmit(event) {
 		const val = this.state.editText.trim();


### PR DESCRIPTION
…ds, by binding the methods

Steps to reproduce errors:
1. `npm install` on the master branch of whitefire-/todomvc
2. `npm start`
3. Go to localhost:3000 (I used Chrome) 
4. Double-click a todo item (for editing)
5. Notice Error comes up on Console (Chrome DevTools):

>  TypeError: Cannot read property 'props' of undefined    TodoItem.js:24
I.e.
```javascript
handleEdit() {
		this.props.onEdit();
```

NEXT (After binding `handleEdit`)
1. Go to localhost:3000
2. Double-click a todo item (works now)
3. Press Enter
4. Notice Error comes up on Console:

> Uncaught TypeError: Cannot read property 'handleSubmit' of undefined    TodoItem.js:16
I.e.
```javascript
handleSubmit(event) {
		const val = this.state.editText.trim();
```

NEXT (After binding `handleSubmit`)
1. Go to localhost:3000
2. Double-click a todo item
3. Press Enter
4. Notice Error comes up on Console:

> Uncaught TypeError: Cannot read property 'handleSubmit' of undefined
     TodoItem.js:36
I.e.
```javascript
handleKeyDown(event) {
...
		this.handleSubmit(event);
```

NEXT (After binding `handleKeyDown`)
1. Go to localhost:3000
2. Double-click a todo item
3. Modify todo item's text
5. Press Enter
4. Notice Error comes up on Console:

> Uncaught TypeError: Cannot read property 'props' of undefined
     TodoItem.js:42
I.e.
```javascript
handleChange(event) {
		if (this.props.editing) {
```

Added binding for `handleChange` to fix.