### PR TITLE
Previous patch (TodoItem.js) + new patch (App.js)

### DIFF
--- a/examples/react/.gitignore
+++ b/examples/react/.gitignore
@@ -17,3 +17,4 @@ yarn-debug.log*
 yarn-error.log*
 todolist.txt
 package-lock.json
+/.vscode

--- a/examples/react/src/App.js
+++ b/examples/react/src/App.js
@@ -92,11 +92,11 @@ class App extends Component {
 				<TodoItem
 					key={todo.id}
 					todo={todo}
-					onToggle={() => this.toggle(todo)}
-					onDestroy={() => this.destroy(todo)}
-					onEdit={() => this.edit(todo)}
+					onToggle={(...args) => this.toggle(todo, ...args)}
+					onDestroy={(...args) => this.destroy(todo, ...args)}
+					onEdit={(...args) => this.edit(todo, ...args)}
 					editing={this.state.editing === todo.id}
-					onSave={() => this.save(todo)}
+					onSave={(...args) => this.save(todo, ...args)}
 					onCancel={this.cancel}
 				/>
 			);

--- a/examples/react/src/App.js
+++ b/examples/react/src/App.js
@@ -19,7 +19,7 @@ class App extends Component {
 		this.clearCompleted = this.clearCompleted.bind(this);
 		this.toggleAll = this.toggleAll.bind(this);
 		this.handleNewTodoKeyDown = this.handleNewTodoKeyDown.bind(this);
-		this.handleChange = this.handleChange.bind(this);	
+		this.handleChange = this.handleChange.bind(this);
 	}
 	handleChange(event) {
 		this.setState({ newTodo: event.target.value });
@@ -84,7 +84,7 @@ class App extends Component {
 					todo={todo}
 					onToggle={() => this.toggle(todo)}
 					onDestroy={() => this.destroy(todo)}
-					onEdit={() => this.edit(todo)}		  
+					onEdit={() => this.edit(todo)}
 					editing={this.state.editing === todo.id}
 					onSave={() => this.save(todo)}
 					onCancel={this.cancel}
@@ -142,7 +142,5 @@ class App extends Component {
 		);
 	}
 }
-
-
 
 export default App;

--- a/examples/react/src/App.js
+++ b/examples/react/src/App.js
@@ -21,9 +21,11 @@ class App extends Component {
 		this.handleNewTodoKeyDown = this.handleNewTodoKeyDown.bind(this);
 		this.handleChange = this.handleChange.bind(this);
 	}
+
 	handleChange(event) {
 		this.setState({ newTodo: event.target.value });
 	}
+
 	handleNewTodoKeyDown(event) {
 		if (event.keyCode !== ENTER_KEY) {
 			return;
@@ -38,29 +40,37 @@ class App extends Component {
 			this.setState({ newTodo: '' });
 		}
 	}
+
 	toggleAll(event) {
 		const checked = event.target.checked;
 		this.props.model.toggleAll(checked);
 	}
+
 	toggle(todoToToggle) {
 		this.props.model.toggle(todoToToggle);
 	}
+
 	destroy(todo) {
 		this.props.model.destroy(todo);
 	}
+
 	edit(todo) {
 		this.setState({ editing: todo.id });
 	}
+
 	save(todoToSave, text) {
 		this.props.model.save(todoToSave, text);
 		this.setState({ editing: null });
 	}
+
 	cancel() {
 		this.setState({ editing: null });
 	}
+
 	clearCompleted() {
 		this.props.model.clearCompleted();
 	}
+
 	render() {
 		let footer;
 		let main;

--- a/examples/react/src/App.js
+++ b/examples/react/src/App.js
@@ -10,6 +10,16 @@ class App extends Component {
 	constructor(props) {
 		super(props);
 		this.state = { nowShowing: ALL_TODOS, editing: null, newTodo: '' };
+
+		this.toggle = this.toggle.bind(this);
+		this.destroy = this.destroy.bind(this);
+		this.edit = this.edit.bind(this);
+		this.save = this.save.bind(this);
+		this.cancel = this.cancel.bind(this);
+		this.clearCompleted = this.clearCompleted.bind(this);
+		this.toggleAll = this.toggleAll.bind(this);
+		this.handleNewTodoKeyDown = this.handleNewTodoKeyDown.bind(this);
+		this.handleChange = this.handleChange.bind(this);	
 	}
 	handleChange(event) {
 		this.setState({ newTodo: event.target.value });
@@ -72,12 +82,12 @@ class App extends Component {
 				<TodoItem
 					key={todo.id}
 					todo={todo}
-					onToggle={this.toggle.bind(this, todo)}
-					onDestroy={this.destroy.bind(this, todo)}
-					onEdit={this.edit.bind(this, todo)}
+					onToggle={() => this.toggle(todo)}
+					onDestroy={() => this.destroy(todo)}
+					onEdit={() => this.edit(todo)}		  
 					editing={this.state.editing === todo.id}
-					onSave={this.save.bind(this, todo)}
-					onCancel={this.cancel.bind(this)}
+					onSave={() => this.save(todo)}
+					onCancel={this.cancel}
 				/>
 			);
 		}, this);
@@ -94,7 +104,7 @@ class App extends Component {
 					count={activeTodoCount}
 					completedCount={completedCount}
 					nowShowing={this.state.nowShowing}
-					onClearCompleted={this.clearCompleted.bind(this)}
+					onClearCompleted={this.clearCompleted}
 				/>
 			);
 		}
@@ -105,7 +115,7 @@ class App extends Component {
 					<input
 						className="toggle-all"
 						type="checkbox"
-						onChange={this.toggleAll.bind(this)}
+						onChange={this.toggleAll}
 						checked={activeTodoCount === 0}
 					/>
 					<ul className="todo-list">{todoItems}</ul>
@@ -121,8 +131,8 @@ class App extends Component {
 						className="new-todo"
 						placeholder="What needs to be done?"
 						value={this.state.newTodo}
-						onKeyDown={this.handleNewTodoKeyDown.bind(this)}
-						onChange={this.handleChange.bind(this)}
+						onKeyDown={this.handleNewTodoKeyDown}
+						onChange={this.handleChange}
 						autoFocus={true}
 					/>
 				</header>

--- a/examples/react/src/TodoItem.js
+++ b/examples/react/src/TodoItem.js
@@ -9,6 +9,11 @@ class TodoItem extends Component {
 	constructor(props) {
 		super(props);
 		this.state = { editText: this.props.todo.title };
+
+		this.handleSubmit = this.handleSubmit.bind(this);
+		this.handleEdit = this.handleEdit.bind(this);
+		this.handleKeyDown = this.handleKeyDown.bind(this);
+		this.handleChange = this.handleChange.bind(this);
 	}
 	handleSubmit(event) {
 		const val = this.state.editText.trim();


### PR DESCRIPTION
This patch is a superset of the previous patch I submitted today, i.e. this patch contains the previous patch, and in this case builds on top of it.

Description:
Moving all `bind`ings to the constructor along with using the binding syntax `(...args) => this.somefunc(...args)` instead of the `this.somefunc.bind(this, ...args)` syntax that exists right now.

AFAIK The main benefit for using `bind` in the constructor is performance.

The arrow functions syntax with the spread operator is required in order to pass additional arguments to the method, from the `TodoItem` component.

I thought this would be useful in order to avoid mismatch of code styles (my previous patch also uses `bind` in the constructor).

Right now the official React docs stick to binding in the constructor.

Alternatives:
1) Dismissing my proposal adopt this `bind`ing pattern, and solving the errors I pointed out to in [Previous patch](https://github.com/whitefire0/todomvc/pull/1#issue-223347504) using the `this.somefunc.bind(this, ...args)` syntax.
2) Adopting the [Class Fields Proposal](https://github.com/tc39/proposal-class-fields) I.e. the following can be an ES6 class method:
```javascript
somefunc = () => {
  // call this function from render 
  // and _this_ keyword should work
};
```
Note that create-react-app already contains the Babel preset that would transpile this experimental syntax automatically.